### PR TITLE
Fix the save file timer overflowing past u16

### DIFF
--- a/src/game/save_file.c
+++ b/src/game/save_file.c
@@ -824,12 +824,12 @@ void save_file_one_second() {
     }
 }
 
-u16 save_file_get_time() {
+u32 save_file_get_time() {
     struct SaveFile *saveFile = &gSaveBuffer.files[gCurrSaveFileNum - 1][0];
     return (saveFile->PlayTime);
 }
 
-u16 save_file_index_get_time(s8 index) {
+u32 save_file_index_get_time(s8 index) {
     struct SaveFile *saveFile = &gSaveBuffer.files[index][0];
     return (saveFile->PlayTime);
 }

--- a/src/game/save_file.h
+++ b/src/game/save_file.h
@@ -244,7 +244,7 @@ u32 save_file_set_progression(u32 prog_enum);
 u32 save_file_get_progression(void);
 
 void save_file_one_second();
-u16 save_file_get_time();
+u32 save_file_get_time();
 u16 save_file_index_get_time(s8 index);
 u16 save_file_index_get_prog(s8 index);
 u8 get_evil_badge_bonus(void);

--- a/src/game/save_file.h
+++ b/src/game/save_file.h
@@ -245,7 +245,7 @@ u32 save_file_get_progression(void);
 
 void save_file_one_second();
 u32 save_file_get_time();
-u16 save_file_index_get_time(s8 index);
+u32 save_file_index_get_time(s8 index);
 u16 save_file_index_get_prog(s8 index);
 u8 get_evil_badge_bonus(void);
 


### PR DESCRIPTION
The save file's `PlayTime` variable is stored as a u32, but the functions `save_file_get_time` and `save_file_index_get_time` return a u16. This makes it so that when it is displayed the time ends up being displayed incorrectly once you've gotten past a little over 18 hours of playtime.

I've not been able to compile the rom with these changes due to it missing some textures for some reason but I'm assuming this change works (though I still think it's a good idea to test it anyway in case I messed something up or forgot something)